### PR TITLE
Removes "from" field limitation of being a number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ module.exports = async ({
 
   const results = await twilio(client, dry).sendAll(
     getRecipients(participants).map((p) => ({
-      from: toNumber(from),
+      from: from,
       to: toNumber(p.number),
       body: message
         .replace("{{name}}", p.name)


### PR DESCRIPTION
This allows to use alphanumeric senders, as explained in: https://support.twilio.com/hc/en-us/articles/223181348-Alphanumeric-Sender-ID-for-Twilio-Programmable-SMS

I could not confirm if this would break tests, as they were already failing on my machine prior to this update. So please forgive me if this breaks tests and you have to fix them :)

Thanks for this by the way ;)